### PR TITLE
Bugfix: Allow empty arrays on transform

### DIFF
--- a/src/main/kotlin/at/willhaben/kafka/connect/transforms/jslt/JsltTransform.kt
+++ b/src/main/kotlin/at/willhaben/kafka/connect/transforms/jslt/JsltTransform.kt
@@ -149,7 +149,10 @@ abstract class JsltTransform<R : ConnectRecord<R>?> : Transformation<R> {
                         convertJsonNodeToValue(elem, schema!!.valueSchema())
                     }.toList()
                 } else {
-                    null
+                    // Do not return null when an empty input array is passed, as this
+                    // would cause the schema validation later on to fail as no optional
+                    // types are created for the source schema.
+                    emptyList()
                 }
             }
             JsonNodeType.BINARY -> jsonNode.binaryValue()


### PR DESCRIPTION
Each time after a JSLT transformation a schema for the output value is inferred from the transformed JSON object, see: https://github.com/willhaben/wh-kafka-connect-jslt-transform/blob/main/src/main/kotlin/at/willhaben/kafka/connect/transforms/jslt/JsltTransform.kt#L111. This schema-inference is not capable of handling optional types, thus each field in the schema is required. 

Subsequently an object with the inferred schema is created (See: https://github.com/willhaben/wh-kafka-connect-jslt-transform/blob/main/src/main/kotlin/at/willhaben/kafka/connect/transforms/jslt/JsltTransform.kt#L114). If the JSLT transformation creates an empty array (e.g. "emptyField": []) the field value was mapped to `null` (https://github.com/willhaben/wh-kafka-connect-jslt-transform/blob/main/src/main/kotlin/at/willhaben/kafka/connect/transforms/jslt/JsltTransform.kt#L152). 
This null-value was then used to set the field in the object with the inferred schema. As this field is non-optional the transformation failed with the following exception:
```
org.apache.kafka.connect.errors.DataException: Invalid value: null used for required field: "someArray", schema type: ARRAY
```

To prevent this issue from happening, empty array values are mapped to an empty list with this PR.