### PR TITLE
Allow schemaless output for jstl transformation output

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@
 
 
 group = "at.willhaben.kafka.connect.transforms.jslt"
-version = System.getenv("VERSION") ?: "1.0.0"
+version = System.getenv("VERSION") ?: "1.2.0"
 
 val javaVersion = 11
 


### PR DESCRIPTION
This PR introduces to option `jslt.schemaless` to write output values of an JSLT transformation without an schema.

This option is introduced as the schema from an output is interfered by the first array object only, which can cause problems if there are several different objects types in an array. 